### PR TITLE
fix: README 링크 오류 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## 목표
 
-**React-Ko-Form** 레포지토리는 **React Hook Form**의 공식 문서(https://react-hook-form.com/docs)를 한국어로 번역하는 프로젝트입니다. 이 레포지토리는 비공식 한국어 문서로서, React Hook Form의 공식 레포지토리와는 별개로 유지됩니다.
+**React-Ko-Form** 레포지토리는 **React Hook Form**의 공식 문서([https://react-hook-form.com/docs](https://react-hook-form.com/docs)) 를 한국어로 번역하는 프로젝트입니다. 이 레포지토리는 비공식 한국어 문서로서, React Hook Form의 공식 레포지토리와는 별개로 유지됩니다.
 
 이 프로젝트는 React Hook Form을 사용하는 한국어 개발자들의 편의성을 높이는 것을 목표로 합니다.
 


### PR DESCRIPTION
### AS-IS
- 현재 README의 React Hook Form의 공식 문서 링크가 잘못 연결되어 오류 발생
<img width="400" alt="스크린샷 2025-02-11 오후 6 46 34" src="https://github.com/user-attachments/assets/7a62011c-d3e8-423b-9be3-2dac6b8509f7" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b36878c3-621f-44e2-adb7-f52952c8540b" />

### TO-BE
- React Hook Form의 공식 문서 링크 마크다운 수정