### PR TITLE
Feat: github href 연결 배너 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,6 @@
     "*.{ts,tsx,mdx,css,json}": [
       "npm run format"
     ]
-  }
+  },
+  "packageManager": "pnpm@9.15.1+sha512.1acb565e6193efbebda772702950469150cf12bcc764262e7587e71d19dc98a423dff9536e57ea44c49bdf790ff694e83c27be5faa23d67e0c033b583be4bfcf"
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,5 @@
     "*.{ts,tsx,mdx,css,json}": [
       "npm run format"
     ]
-  },
-  "packageManager": "pnpm@9.15.1+sha512.1acb565e6193efbebda772702950469150cf12bcc764262e7587e71d19dc98a423dff9536e57ea44c49bdf790ff694e83c27be5faa23d67e0c033b583be4bfcf"
+  }
 }

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -3,6 +3,7 @@ import { getEditLink } from "./logic/getEditLink"
 import Nav from "./Nav"
 import { useEffect, useState, ReactNode } from "react"
 import { useRouter } from "next/router"
+import { Banner } from "@/react-ko-form/components/Banner"
 
 const Layout = ({ children }: { children: ReactNode }) => {
   const router = useRouter()
@@ -42,6 +43,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
       <a className="skip-main" href="#main">
         Skip to content
       </a>
+      <Banner />
       <Nav />
       {children}
       <Animate

--- a/src/react-ko-form/components/Banner.module.css
+++ b/src/react-ko-form/components/Banner.module.css
@@ -1,12 +1,39 @@
 .container {
-  background-color: #000;
-  height: 60px;
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
+  background-color: #000;
+  padding: 8px 16px;
+  height: 60px;
 }
 
 .link {
+  display: block;
+  margin: 0 auto;
+  max-width: calc(100% - 267px);
   color: #fff;
   text-decoration: none;
+  text-align: center;
+  white-space: normal;
+  word-break: break-word;
+  overflow: hidden;
+}
+
+@media (max-width: 767px) {
+  .container {
+    position: static;
+    margin-top: 60px;
+    height: auto;
+    padding: 8px 16px;
+  }
+
+  .link {
+    position: static;
+    transform: none;
+    left: auto;
+    max-width: none;
+    white-space: normal;
+    word-break: break-word;
+  }
 }

--- a/src/react-ko-form/components/Banner.module.css
+++ b/src/react-ko-form/components/Banner.module.css
@@ -1,6 +1,6 @@
 .container {
   background-color: #000;
-  height: 40px;
+  height: 60px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/react-ko-form/components/Banner.module.css
+++ b/src/react-ko-form/components/Banner.module.css
@@ -1,0 +1,12 @@
+.container {
+  background-color: #000;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.link {
+  color: #fff;
+  text-decoration: none;
+}

--- a/src/react-ko-form/components/Banner.tsx
+++ b/src/react-ko-form/components/Banner.tsx
@@ -1,0 +1,16 @@
+import styles from "./Banner.module.css"
+
+export const Banner = () => {
+  return (
+    <div className={styles.container}>
+      <a
+        href="https://github.com/hamsurang/react-ko-form"
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.link}
+      >
+        ⛰️ 같이 발전시켜 나가요! React Hook Form 번역하러 가기 ⛰️
+      </a>
+    </div>
+  )
+}


### PR DESCRIPTION
- react-ko-form 레포지토리로 연결되는 배너를 추가했습니다. 
![image](https://github.com/user-attachments/assets/c1213806-b58a-42fc-95d6-ca3121b88bd4)
- 배너는 src/react-ko-form 디렉토리를 추가하여 하위에 위치시켰습니다. 
```
.gitHubButtonWrap {
  position: absolute;
  right: 10px;
  top: 15px;
  z-index: 1;
  display: flex;
  gap: 4px;
}
```
- 위와 같이 기존 상단에 위치한 Nav의 일부 스타일이 absolute로 설정되어있습니다. 원본 src의 변경은 최소화하기 위해 기존 github icon 이나 searchBar와 배너의 겹침은 고려하지 않았습니다. 

