### PR TITLE
fix: Prevent double rendering of pages by removing duplicated <Compon…

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -52,7 +52,6 @@ function App({ Component, pageProps }: AppProps) {
           <PostHogProvider>
             <Component {...pageProps} />
           </PostHogProvider>
-          <Component {...pageProps} />
         </StateMachineProvider>
       </ThemeProvider>
     </>


### PR DESCRIPTION
This PR removes the duplicated `<Component {...pageProps} />` inside the App component, which was causing all pages to render twice.

**Example Page Image**
![스크린샷 2025-05-14 오후 9 07 27](https://github.com/user-attachments/assets/dfb17d23-1149-4b84-bda8-a58f9cb2d7fd)
