### PR TITLE
feat: Claude Code 플러그인 및 스킬 추가 (guide, recommend, form-builder)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "react-ko-form-plugin",
+  "owner": {
+    "name": "hamsurang"
+  },
+  "metadata": {
+    "description": "React Hook Form skills for Claude Code — guide, recommend, and form builder",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "react-ko-form",
+      "source": "./react-ko-form-plugin"
+    }
+  ]
+}

--- a/react-ko-form-plugin/.claude-plugin/plugin.json
+++ b/react-ko-form-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "react-ko-form",
+  "version": "0.1.0",
+  "description": "React Hook Form best practices: setup guide, API recommendation, and form code scaffolding",
+  "author": {
+    "name": "hamsurang"
+  },
+  "homepage": "https://react-ko-form.netlify.app",
+  "repository": "https://github.com/hamsurang/react-ko-form",
+  "license": "MIT",
+  "keywords": ["react-hook-form", "form", "validation", "react", "hook"]
+}

--- a/react-ko-form-plugin/README.md
+++ b/react-ko-form-plugin/README.md
@@ -1,0 +1,63 @@
+# react-ko-form plugin
+
+React Hook Form skills for Claude Code — setup guide, API recommendation, and form code scaffolding.
+
+Each skill reads local documentation bundled via symlinks, so all recommendations are grounded in the actual API reference — no network requests needed.
+
+## Installation
+
+### Claude Code Plugin Marketplace (recommended)
+
+```
+claude plugin install hamsurang/react-ko-form
+```
+
+### Via npx skills
+
+```
+npx skills add hamsurang/react-ko-form
+```
+
+### Local Development
+
+```
+claude --plugin-dir ./react-ko-form-plugin
+```
+
+## Skills
+
+| Skill | Command | Description |
+|-------|---------|-------------|
+| Guide | `/react-ko-form:guide` | Installation, setup, and hook usage guide |
+| Recommend | `/react-ko-form:recommend` | Find the right API or pattern for your use case |
+| Form Builder | `/react-ko-form:form-builder` | Generate typed form code from natural language |
+
+## Usage Examples
+
+```
+/react-ko-form:guide useForm
+/react-ko-form:guide validation
+/react-ko-form:recommend I need to watch all form values without re-rendering
+/react-ko-form:form-builder login form with email and password
+/react-ko-form:form-builder registration form with name, email, password, confirm password, and terms checkbox
+```
+
+## How It Works
+
+Skills reference local documentation from the `origin-src/content/` directory (English MDX files) and code examples from `origin-src/components/codeExamples/`. Documentation is linked via symlinks so it stays in sync with the repository.
+
+Based on react-hook-form v7.x documentation.
+
+## Platform Note
+
+On Windows, ensure symlinks are enabled:
+
+```
+git config core.symlinks true
+```
+
+Then re-clone the repository for symlinks to resolve correctly.
+
+## License
+
+MIT

--- a/react-ko-form-plugin/skills/form-builder/SKILL.md
+++ b/react-ko-form-plugin/skills/form-builder/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: form-builder
+description: Generate complete React Hook Form code from natural language field definitions. Use when the user wants to scaffold a typed form with validation and error handling.
+argument-hint: '<form description: e.g., login form with email and password>'
+allowed-tools: Read, Glob, Grep, Write
+---
+
+# form-builder
+
+Generate a complete, typed React Hook Form component from a plain-language description.
+
+## Source-of-Truth Grounding
+
+Before generating code, always verify API options from local docs:
+
+- Register validation options: `${CLAUDE_SKILL_DIR}/docs/docs/useform/register.mdx`
+- useForm options (mode, defaultValues, etc.): `${CLAUDE_SKILL_DIR}/docs/docs/useform.mdx` — skip the first 79 lines (SelectNav navigation component, content starts at line 80)
+
+## MDX Component Glossary
+
+- `<TypeText>T</TypeText>` or `<TypeText pre>T</TypeText>` — inline type annotation. Read the text content as the TypeScript type.
+- `<PrettyObject value={{key: 'type', ...}}/>` — renders a type shape. Read the `value` prop as the type definition.
+- `<TabGroup buttonLabels={["X", "Y"]}>` — tabbed content with alternative views (e.g., TS vs JS). Read all tabs as variants.
+- `<Admonition type="note|important|tip" title="...">` — callout block. Always read; contains critical rules or caveats.
+- `<SelectNav options={[...]}>` — navigation menu. Skip for content purposes.
+- `<CodeArea>` — code display component. Read the code content within.
+- `<Popup message="...">` — tooltip hint. The `message` prop contains supplementary info.
+- Ignore: `<div style={...}>`, `import ...`, `export ...` statements.
+
+## $ARGUMENTS Handling
+
+**Arguments provided** → parse field definitions → follow the Code Generation Workflow below.
+
+**No arguments** → show the following examples and ask the user to describe their form:
+
+```
+Usage examples:
+  /react-ko-form:form-builder login form with email and password
+  /react-ko-form:form-builder registration with name, email, password (min 8), confirm password, and terms checkbox
+  /react-ko-form:form-builder contact form with name, email, phone (optional), and message (textarea)
+
+Describe your form and I'll generate the complete TypeScript component.
+```
+
+## Code Generation Workflow
+
+### Step 1 — Parse the input
+
+Extract from the natural language description:
+
+- Field names
+- Field types (text, email, password, number, checkbox, textarea, select, URL, phone)
+- Validation requirements (required, minLength, maxLength, pattern, min, max, validate)
+- Optional vs required fields
+
+### Step 2 — Read local docs
+
+Read both files to verify current API options before generating:
+
+1. `${CLAUDE_SKILL_DIR}/docs/docs/useform/register.mdx` — validation rule options
+2. `${CLAUDE_SKILL_DIR}/docs/docs/useform.mdx` (from line 80) — useForm options
+
+### Step 3 — Generate the component
+
+Produce all of the following in order:
+
+1. TypeScript `interface` for form field types
+2. `useForm<T>()` hook setup with appropriate options
+3. `register()` calls with validation rules
+4. `formState.errors` error handling for each validated field
+5. `handleSubmit` + `onSubmit` function
+6. Complete JSX form component
+
+## Complexity Limit
+
+For forms with **more than 8 fields**: generate the TypeScript interface and `useForm` setup first, then ask the user to confirm before generating the full JSX.
+
+## Common Validation Patterns
+
+| Field Type | Validation Rules |
+|---|---|
+| email | `{ required: "Email is required", pattern: { value: /\S+@\S+\.\S+/, message: "Invalid email" } }` |
+| password | `{ required: "Password is required", minLength: { value: 8, message: "At least 8 characters" } }` |
+| confirm password | `{ validate: (value, formValues) => value === formValues.password \|\| "Passwords do not match" }` |
+| phone | `{ pattern: { value: /^\+?[0-9\s\-()]{7,15}$/, message: "Invalid phone number" } }` |
+| number | `{ min: 0, max: 999, valueAsNumber: true }` |
+| URL | `{ pattern: { value: /^https?:\/\/.+/, message: "Invalid URL" } }` |
+| required checkbox | `{ required: "You must accept the terms" }` |
+| textarea | `{ required: "Message is required", maxLength: { value: 500, message: "Max 500 characters" } }` |
+
+## Dynamic Fields (useFieldArray)
+
+`useFieldArray` has no MDX documentation. When dynamic fields are requested:
+
+1. Read `${CLAUDE_SKILL_DIR}/examples/useFieldArray.ts` and `${CLAUDE_SKILL_DIR}/examples/useFieldArrayArgument.ts`
+2. Key API: `useFieldArray({ control, name })` returns `{ fields, append, remove, prepend, swap, move, insert, update, replace }`
+3. Always use `field.id` as key (not array index)
+4. Provide full default shape on `append()`: `append({ name: "", quantity: 1 })`
+5. Register nested fields as: `` register(`items.${index}.name`) ``
+
+## Output Example
+
+Given: "login form with email and password"
+
+```tsx
+import { useForm } from "react-hook-form";
+
+interface LoginFormValues {
+  email: string;
+  password: string;
+}
+
+export function LoginForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginFormValues>({ mode: "onBlur" });
+
+  const onSubmit = (data: LoginFormValues) => console.log(data);
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div>
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          type="email"
+          {...register("email", {
+            required: "Email is required",
+            pattern: { value: /\S+@\S+\.\S+/, message: "Invalid email" },
+          })}
+        />
+        {errors.email && <span>{errors.email.message}</span>}
+      </div>
+
+      {/* Repeat the pattern above for each field */}
+
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+```
+
+## Constraints
+
+- Generate basic HTML elements only (no MUI, shadcn, Chakra, or other UI libraries)
+- Always use TypeScript with generics (`useForm<FormType>`)
+- Always include error handling for each validated field
+- File output: ask the user where to write the file; default to chat output
+
+## Cross-Skill References
+
+- Unsure which API to use? Try `/react-ko-form:recommend`
+- Need detailed API usage? Try `/react-ko-form:guide <api-name>`
+
+---
+
+Based on react-hook-form v7.x documentation.

--- a/react-ko-form-plugin/skills/form-builder/docs
+++ b/react-ko-form-plugin/skills/form-builder/docs
@@ -1,0 +1,1 @@
+../../../origin-src/content

--- a/react-ko-form-plugin/skills/form-builder/examples
+++ b/react-ko-form-plugin/skills/form-builder/examples
@@ -1,0 +1,1 @@
+../../../origin-src/components/codeExamples

--- a/react-ko-form-plugin/skills/guide/SKILL.md
+++ b/react-ko-form-plugin/skills/guide/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: guide
+description: React Hook Form installation, setup, and hook usage guide. Use when the user asks how to install, configure, or use react-hook-form in their project.
+argument-hint: '<topic: e.g., useForm, validation, getting started>'
+allowed-tools: Read, Glob, Grep
+---
+
+# React Hook Form Guide
+
+react-hook-form evolves across versions. Always verify from local docs rather than relying on memorized instructions. The docs in this skill directory are the source of truth.
+
+**Version note:** Based on react-hook-form v7.x documentation.
+
+## MDX Component Glossary
+
+The docs use custom JSX components. Interpret them as follows:
+
+- `<TypeText>T</TypeText>` or `<TypeText pre>T</TypeText>` — inline type annotation. Read the text content as the TypeScript type.
+- `<PrettyObject value={{key: 'type', ...}}/>` — renders a type shape. Read the `value` prop as the type definition.
+- `<TabGroup buttonLabels={["X", "Y"]}>` — tabbed content with alternative views (e.g., TS vs JS). Read all tabs as variants.
+- `<Admonition type="note|important|tip" title="...">` — callout block. Always read; contains critical rules or caveats.
+- `<SelectNav options={[...]}>` — navigation menu. Skip for content purposes.
+- `<CodeArea>` — code display component. Read the code content within.
+- `<Popup message="...">` — tooltip hint. The `message` prop contains supplementary info.
+- Ignore: `<div style={...}>`, `import ...`, `export ...` statements.
+
+---
+
+## Instructions
+
+You are a react-hook-form guide. Use `$ARGUMENTS` to determine the scope of your response.
+
+### Step 1 — Classify the request
+
+| Input | Action |
+|---|---|
+| Empty / "getting started" / "how to install" | Full getting-started guide |
+| Hook name (`useForm`, `register`, `useController`, `useFieldArray`, `useFormState`, `useWatch`, `useFormContext`, `useLens`) | API deep-dive for that hook |
+| Concept (`validation`, `error handling`, `controlled`, `schema`, `TypeScript`) | Search advanced-usage + faqs for relevant sections |
+
+### Step 2 — Read the relevant local docs
+
+**Getting started (no arguments or install/setup questions):**
+
+1. Read `${CLAUDE_SKILL_DIR}/docs/get-started.mdx` — installation, basic setup, first form
+2. Skim `${CLAUDE_SKILL_DIR}/docs/docs/useform.mdx` from line 80 — useForm overview (skip first 79 lines of SelectNav)
+
+**Hook-specific topics:**
+
+- `useForm` → `${CLAUDE_SKILL_DIR}/docs/docs/useform.mdx` (from line 80) and subdirectory files in `${CLAUDE_SKILL_DIR}/docs/docs/useform/` (including `subscribe` subpage)
+- `useController` → `${CLAUDE_SKILL_DIR}/docs/docs/usecontroller/` files
+- `useFieldArray` → no dedicated MDX. Search `${CLAUDE_SKILL_DIR}/docs/advanced-usage.mdx` for mentions, and check `${CLAUDE_SKILL_DIR}/examples/useFieldArray.ts` and `useFieldArrayArgument.ts` for usage patterns
+- `useFormState` → `${CLAUDE_SKILL_DIR}/docs/docs/useformstate.mdx` and `${CLAUDE_SKILL_DIR}/docs/docs/useformstate/`
+- `useWatch` → `${CLAUDE_SKILL_DIR}/docs/docs/usewatch.mdx` and `${CLAUDE_SKILL_DIR}/docs/docs/usewatch/`
+- `useFormContext` / `FormProvider` → `${CLAUDE_SKILL_DIR}/docs/docs/useformcontext.mdx` and `${CLAUDE_SKILL_DIR}/docs/docs/formprovider.mdx`
+- `useLens` → `${CLAUDE_SKILL_DIR}/docs/docs/uselens.mdx`
+
+**Concept topics:**
+
+- `validation`, `schema`, `resolver` → `${CLAUDE_SKILL_DIR}/docs/get-started.mdx` (Schema Validation section) + `${CLAUDE_SKILL_DIR}/docs/advanced-usage.mdx`
+- `error handling`, `errors` → `${CLAUDE_SKILL_DIR}/docs/get-started.mdx` + `${CLAUDE_SKILL_DIR}/docs/docs/useform/` (`formstate` subpage)
+- `TypeScript` → `${CLAUDE_SKILL_DIR}/docs/ts.mdx`
+- `controlled components`, `Controller` → `${CLAUDE_SKILL_DIR}/docs/get-started.mdx` + `${CLAUDE_SKILL_DIR}/docs/docs/usecontroller/`
+- `FAQ` or general questions → `${CLAUDE_SKILL_DIR}/docs/faqs.mdx`
+- `advanced` patterns → `${CLAUDE_SKILL_DIR}/docs/advanced-usage.mdx`
+
+**Code examples directory:** `${CLAUDE_SKILL_DIR}/examples/` — reference `.ts` / `.tsx` files by name when showing usage patterns.
+
+### Step 3 — Compose the response
+
+Structure your output using these sections. Omit sections that are not relevant to the topic.
+
+#### 1. Overview
+1–2 sentences summarizing the topic.
+
+#### 2. Setup (if relevant)
+Installation command, required imports, and any prerequisites (e.g., resolver packages for schema validation).
+
+#### 3. Usage
+Core API with a concise code example drawn from the local docs or examples directory. Prefer TypeScript variants when showing code.
+
+#### 4. Options
+Relevant options table extracted from the docs. Include type, default value, and description columns where available.
+
+#### 5. Common Patterns
+2–4 practical patterns from `advanced-usage.mdx` or the examples directory that address the topic.
+
+#### 6. Gotchas
+Caveats surfaced from `<Admonition>` blocks in the docs. These are load-bearing — always include them when present.
+
+#### 7. Related
+- Local doc paths the user can read for deeper detail
+- Cross-skill suggestions (see below)
+
+---
+
+## Cross-Skill References
+
+- If the user is choosing between multiple APIs or patterns (e.g., "should I use `register` or `Controller`?"), suggest `/react-ko-form:recommend` instead.
+- If the user wants to generate form code from a schema or field list, suggest `/react-ko-form:form-builder` instead.
+

--- a/react-ko-form-plugin/skills/guide/docs
+++ b/react-ko-form-plugin/skills/guide/docs
@@ -1,0 +1,1 @@
+../../../origin-src/content

--- a/react-ko-form-plugin/skills/guide/examples
+++ b/react-ko-form-plugin/skills/guide/examples
@@ -1,0 +1,1 @@
+../../../origin-src/components/codeExamples

--- a/react-ko-form-plugin/skills/recommend/SKILL.md
+++ b/react-ko-form-plugin/skills/recommend/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: recommend
+description: Recommend the right React Hook Form API or pattern for your use case. Use when the user asks which hook, component, or pattern to use for a specific form requirement.
+argument-hint: '<use case: e.g., watch all fields, dynamic field arrays, schema validation>'
+allowed-tools: Read, Glob, Grep
+---
+
+# React Hook Form API Recommendation
+
+Recommend the most suitable React Hook Form API or pattern for the user's needs, grounded in the local documentation.
+
+react-hook-form evolves across versions. Always verify from local docs in this skill directory rather than relying on memorized knowledge.
+
+## MDX Component Glossary
+
+The local docs are MDX files with custom components. Parse them as follows:
+
+- `<TypeText>T</TypeText>` or `<TypeText pre>T</TypeText>` — inline type annotation. Read the text content as the TypeScript type.
+- `<PrettyObject value={{key: 'type', ...}}/>` — renders a type shape. Read the `value` prop as the type definition.
+- `<TabGroup buttonLabels={["X", "Y"]}>` — tabbed content with alternative views (e.g., TS vs JS). Read all tabs as variants.
+- `<Admonition type="note|important|tip" title="...">` — callout block. Always read; contains critical rules or caveats.
+- `<SelectNav options={[...]}>` — navigation menu. Skip for content purposes.
+- `<CodeArea>` — code display component. Read the code content within.
+- `<Popup message="...">` — tooltip hint. The `message` prop contains supplementary info.
+- Ignore: `<div style={...}>`, `import ...`, `export ...` statements.
+
+## API Mapping Table
+
+Use this table to match developer intent to the correct API:
+
+| Developer Intent | Recommended API | Local Doc Path |
+|---|---|---|
+| basic form setup | `useForm` + `register` | `${CLAUDE_SKILL_DIR}/docs/docs/useform.mdx` |
+| validate fields | `register` rules or `resolver` | `${CLAUDE_SKILL_DIR}/docs/docs/useform/register.mdx` |
+| dynamic add/remove fields | `useFieldArray` | `${CLAUDE_SKILL_DIR}/examples/useFieldArray.ts` (no MDX) |
+| controlled/UI library components | `Controller` / `useController` | `${CLAUDE_SKILL_DIR}/docs/docs/usecontroller/controller.mdx` |
+| share form state across components | `FormProvider` + `useFormContext` | `${CLAUDE_SKILL_DIR}/docs/docs/useformcontext.mdx`, `${CLAUDE_SKILL_DIR}/docs/docs/formprovider.mdx` |
+| watch a specific field | `useWatch` | `${CLAUDE_SKILL_DIR}/docs/docs/usewatch.mdx` |
+| watch from parent (root level) | `watch` (from useForm) | `${CLAUDE_SKILL_DIR}/docs/docs/useform/watch.mdx` |
+| multi-step form | `useFormContext` + `trigger()` | `${CLAUDE_SKILL_DIR}/docs/advanced-usage.mdx` |
+| load async data into form | `values` prop (not `defaultValues`) | `${CLAUDE_SKILL_DIR}/docs/docs/useform.mdx` |
+| schema validation (Zod/Yup) | `@hookform/resolvers` | `${CLAUDE_SKILL_DIR}/docs/get-started.mdx` |
+| debug form state | `@hookform/devtools` | (training data only — limit to install guidance) |
+| set server-side errors | `setError()` | `${CLAUDE_SKILL_DIR}/docs/docs/useform/seterror.mdx` |
+| set values programmatically | `setValue()` | `${CLAUDE_SKILL_DIR}/docs/docs/useform/setvalue.mdx` |
+| check dirty/valid state | `formState` | `${CLAUDE_SKILL_DIR}/docs/docs/useform/formstate.mdx` |
+| reset form to defaults | `reset()` | `${CLAUDE_SKILL_DIR}/docs/docs/useform/reset.mdx` |
+| reset a single field | `resetField()` | `${CLAUDE_SKILL_DIR}/docs/docs/useform/resetfield.mdx` |
+| read current values without subscription | `getValues()` | `${CLAUDE_SKILL_DIR}/docs/docs/useform/getvalues.mdx` |
+| clear specific errors | `clearErrors()` | `${CLAUDE_SKILL_DIR}/docs/docs/useform/clearerrors.mdx` |
+| check if a field is dirty/touched | `getFieldState()` | `${CLAUDE_SKILL_DIR}/docs/docs/useform/getfieldstate.mdx` |
+| focus a field programmatically | `setFocus()` | `${CLAUDE_SKILL_DIR}/docs/docs/useform/setfocus.mdx` |
+| remove a registered field | `unregister()` | `${CLAUDE_SKILL_DIR}/docs/docs/useform/unregister.mdx` |
+| handle form submission | `handleSubmit()` | `${CLAUDE_SKILL_DIR}/docs/docs/useform/handlesubmit.mdx` |
+| subscribe to form state changes outside React | `subscribe()` | `${CLAUDE_SKILL_DIR}/docs/docs/useform/subscribe.mdx` |
+| type-safe functional lenses | `useLens` | `${CLAUDE_SKILL_DIR}/docs/docs/uselens.mdx` |
+
+## Workflow
+
+### If $ARGUMENTS is provided
+
+1. Parse $ARGUMENTS to identify the developer intent (what form behavior they need).
+2. Match against the API Mapping Table above.
+3. If no direct match, search local docs by keyword:
+   ```
+   Grep for keywords in ${CLAUDE_SKILL_DIR}/docs/**/*.mdx
+   ```
+4. Read the matched doc file to extract the exact signature, options, and an example.
+5. If multiple APIs are plausible, read each relevant doc and compare.
+6. Respond using the Output Format below.
+
+### If $ARGUMENTS is empty
+
+Display the full API Mapping Table and ask:
+
+> "Describe your form requirement and I'll recommend the right React Hook Form API."
+
+## Special Case: useFieldArray
+
+`useFieldArray` has no MDX documentation in the local docs directory. When recommending it:
+
+1. Read `${CLAUDE_SKILL_DIR}/examples/useFieldArray.ts` for the primary usage pattern.
+2. Read `${CLAUDE_SKILL_DIR}/examples/useFieldArrayArgument.ts` for argument shapes.
+3. Inform the user: "Local docs are limited for `useFieldArray` — the recommendation below is based on code examples."
+4. Still provide a complete recommendation with the import path and code patterns extracted from the examples.
+
+## Output Format
+
+For each recommended API, respond with this structure:
+
+### 1. Recommended API
+
+State the API name clearly: e.g., **`useFieldArray`**
+
+### 2. Description
+
+One sentence describing what it does, sourced from the local doc or example file.
+
+### 3. Import
+
+```ts
+import { useForm, useFieldArray } from 'react-hook-form';
+```
+
+### 4. Code Example
+
+Extract a minimal, self-contained example from the local docs or examples directory.
+
+### 5. Comparison Table (when multiple options exist)
+
+| API | Use Case | Performance | Complexity |
+|---|---|---|---|
+| `watch` | parent-level subscription | re-renders parent | low |
+| `useWatch` | isolated field subscription | isolated re-renders | low |
+
+### 6. When to choose which
+
+Clear decision criteria — e.g., "Use `useWatch` to subscribe to a single field without re-rendering the parent. Use `watch` when you need the value at the root level or outside a component."
+
+### 7. Related Docs
+
+List local doc paths that were referenced:
+- `${CLAUDE_SKILL_DIR}/docs/docs/usewatch.mdx`
+- `${CLAUDE_SKILL_DIR}/docs/docs/useform/watch.mdx`
+
+## Cross-Skill References
+
+After delivering a recommendation:
+
+- For detailed usage instructions on the chosen API: suggest `/react-ko-form:guide <api-name>`
+- For generating a complete form component: suggest `/react-ko-form:form-builder`
+
+## Version Note
+
+Based on react-hook-form v7.x documentation.

--- a/react-ko-form-plugin/skills/recommend/docs
+++ b/react-ko-form-plugin/skills/recommend/docs
@@ -1,0 +1,1 @@
+../../../origin-src/content

--- a/react-ko-form-plugin/skills/recommend/examples
+++ b/react-ko-form-plugin/skills/recommend/examples
@@ -1,0 +1,1 @@
+../../../origin-src/components/codeExamples


### PR DESCRIPTION
## Summary

- react-hook-form 사용자를 위한 Claude Code 플러그인 생성 (es-toolkit 패턴)
- 3개 스킬: guide (설치/사용법), recommend (API 추천), form-builder (폼 코드 생성)
- symlink로 `origin-src/content/` 영어 원본 MDX + `origin-src/components/codeExamples/` 번들링
- Claude plugin marketplace + npx skills 양쪽 배포 호환

## Plugin Structure

```
.claude-plugin/marketplace.json          # hamsurang/react-ko-form
react-ko-form-plugin/
├── .claude-plugin/plugin.json
├── README.md
└── skills/
    ├── guide/SKILL.md       (100줄, Read/Glob/Grep)
    ├── recommend/SKILL.md   (138줄, Read/Glob/Grep, 24-entry 매핑 테이블)
    └── form-builder/SKILL.md (160줄, Read/Glob/Grep/Write)
```

## Skills

| Skill | Command | Description |
|-------|---------|-------------|
| Guide | `/react-ko-form:guide` | 설치, 설정, hook 사용법 안내 |
| Recommend | `/react-ko-form:recommend` | 유스케이스 기반 API/패턴 추천 |
| Form Builder | `/react-ko-form:form-builder` | 자연어 → TypeScript 폼 코드 생성 |

## Eval Results

6개 테스트 케이스 실행, **32/32 assertions passed (100%)**

![eval-dashboard](https://files.catbox.moe/v2s2yc.png)

## Test plan

- [x] `claude --plugin-dir ./react-ko-form-plugin` 로컬 로드 테스트
- [x] `/react-ko-form:guide useForm` 응답 확인
- [x] `/react-ko-form:recommend` 매핑 테이블 동작 확인
- [x] `/react-ko-form:form-builder login form with email and password` 코드 생성 확인
- [x] symlink 정상 동작 (macOS/Linux)

<img width="748" height="665" alt="image" src="https://github.com/user-attachments/assets/1f73024c-146b-4000-882d-547c103ee067" />

<img width="561" height="742" alt="image" src="https://github.com/user-attachments/assets/7c114321-45e6-48ad-9c6a-e5f6241d7642" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)