### PR TITLE
fix: 검색 결과가 한국어 사이트 내부로 이동하도록 수정

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,8 +1,12 @@
 import { useRef, useEffect } from "react"
+import { useRouter } from "next/router"
 import clsx from "clsx"
 import searchStyles from "./Search.module.css"
 import useWindowSize from "./utils/useWindowSize"
 import { LARGE_SCREEN } from "../styles/breakpoints"
+
+const ORIGINAL_SITE_URL = "https://react-hook-form.com"
+const KO_SITE_URL = "https://react-ko-form.netlify.app"
 
 const Search = ({
   focus,
@@ -11,6 +15,7 @@ const Search = ({
   focus: boolean
   setFocus: (value: boolean) => void
 }) => {
+  const router = useRouter()
   const { width } = useWindowSize()
   const searchRef = useRef<HTMLInputElement | null>(null)
 
@@ -20,12 +25,24 @@ const Search = ({
       apiKey: "c56a3f265ffbf85c2c654f865cb09164",
       indexName: "react-hook-form",
       inputSelector: "#algolia-doc-search",
+      transformData(suggestions) {
+        return suggestions.map((suggestion) => ({
+          ...suggestion,
+          url: suggestion.url.replace(ORIGINAL_SITE_URL, KO_SITE_URL),
+        }))
+      },
+      handleSelected(_input, event, suggestion) {
+        event.preventDefault()
+        const url = new URL(suggestion.url)
+        const path = url.pathname + url.hash
+        router.push(path)
+      },
     })
 
     return () => {
       setFocus(false)
     }
-  }, [setFocus])
+  }, [setFocus, router])
 
   useEffect(() => {
     if (LARGE_SCREEN <= width) {

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -33,9 +33,12 @@ const Search = ({
       },
       handleSelected(_input, event, suggestion) {
         event.preventDefault()
-        const url = new URL(suggestion.url)
-        const path = url.pathname + url.hash
-        router.push(path)
+        try {
+          const url = new URL(suggestion.url)
+          router.push(url.pathname + url.hash)
+        } catch {
+          router.push(suggestion.url)
+        }
       },
     })
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -4,7 +4,15 @@ interface Window {
     apiKey: string
     indexName: string
     inputSelector: string
-  }) => vod
+    transformData?: (suggestions: Array<{ url: string; [key: string]: unknown }>) => Array<{ url: string; [key: string]: unknown }>
+    handleSelected?: (
+      input: HTMLInputElement,
+      event: Event,
+      suggestion: { url: string; [key: string]: unknown },
+      datasetNumber: number,
+      context: { selectionMethod: string }
+    ) => void
+  }) => void
 }
 
 declare module "*.mdx" {


### PR DESCRIPTION
## Summary

- 검색바(DocSearch)에서 검색 시 원문 사이트(`react-hook-form.com`)로 이동하던 문제 수정
- `transformData` 콜백으로 Algolia 검색 결과 URL을 한국어 사이트(`react-ko-form.netlify.app`)로 변환
- `handleSelected` 콜백으로 Next.js `router.push()`를 사용한 클라이언트 사이드 내비게이션 구현
- URL 파싱 실패 시 fallback 처리 추가

## 변경 파일

- `src/types/global.d.ts` — `docsearch` 타입에 `transformData`, `handleSelected` 옵션 추가
- `src/components/Search.tsx` — URL 변환 로직 및 클라이언트 사이드 내비게이션 구현

## Test Plan

- [x] 검색바에 "useForm" 입력 후 드롭다운 결과 URL이 `react-ko-form.netlify.app`인지 확인
- [x] 검색 결과 클릭 시 한국어 사이트 내부 페이지로 이동하는지 확인
- [x] 페이지 전체 리로드 없이 클라이언트 사이드로 이동하는지 확인
- [x] 해시(#) 포함 URL 클릭 시 해당 앵커로 정상 이동하는지 확인
- [x] TypeScript 빌드 에러 없음 확인 (기존 에러 4개 외 신규 에러 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)